### PR TITLE
fix(ci): acceptance tests failing only during CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,9 @@ jobs:
           tags: tag:ci
           version: 1.78.1
       - name: Check Coolify API health
-        run: curl --silent --fail --max-time 15 "${COOLIFY_ENDPOINT}/api/health" | grep --quiet "^OK$"
+        run: |
+          response=$(curl -sf "${COOLIFY_ENDPOINT}/../health" || echo "Failed to connect")
+          echo "$response" | grep -q "^OK$" || { echo "Health check failed. Got: $response"; exit 1; }
         env:
           COOLIFY_ENDPOINT: ${{ secrets.ACC_COOLIFY_ENDPOINT }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
           tags: tag:ci
           version: 1.78.1
       - name: Check Coolify API health
-        run: curl -sf "${COOLIFY_ENDPOINT}/api/health" | grep -q "^OK$"
+        run: curl --silent --fail --max-time 15 "${COOLIFY_ENDPOINT}/api/health" | grep --quiet "^OK$"
         env:
           COOLIFY_ENDPOINT: ${{ secrets.ACC_COOLIFY_ENDPOINT }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run go test
         run: |
           go clean -testcache
-          go test -v -timeout=1m \
+          go test -v -timeout=5m \
             -cover -coverprofile=coverage.txt -covermode=atomic \
             -run '^(TestProtocol6ProviderServerConfigure)' \
             ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,10 +143,10 @@ jobs:
           statedir: /tmp/tailscale-state/
           tags: tag:ci
           version: 1.76.6
-      - name: Run Acceptance Tests
+      - name: Run go test
         run: |
           go clean -testcache
-          go test -v -timeout=5m \
+          go test -v -timeout=1m \
             -cover -coverprofile=coverage.txt -covermode=atomic \
             -run '^(TestProtocol6ProviderServerConfigure)' \
             ./...
@@ -155,7 +155,7 @@ jobs:
           TF_LOG: DEBUG
           COOLIFY_ENDPOINT: ${{ secrets.ACC_COOLIFY_ENDPOINT }}
           COOLIFY_TOKEN: ${{ secrets.ACC_COOLIFY_TOKEN }}
-        timeout-minutes: 6
+        timeout-minutes: 10
 
       # - uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
       #   if: ${{ !cancelled() && !startsWith(github.head_ref, 'renovate/') && matrix.tool == 'terraform' && matrix.version == 'v1.9.x' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,28 +142,35 @@ jobs:
           authkey: ${{ secrets.TS_AUTHKEY }}
           statedir: /tmp/tailscale-state/
           tags: tag:ci
-          version: 1.76.6
+          version: 1.78.1
+      - name: Check Coolify API health
+        run: curl -sf "${COOLIFY_ENDPOINT}/api/health" | grep -q "^OK$"
+        env:
+          COOLIFY_ENDPOINT: ${{ secrets.ACC_COOLIFY_ENDPOINT }}
+
       - name: Run go test
         run: |
           go clean -testcache
-          go test -v -timeout=5m \
+          go test -v -timeout=10m \
             -cover -coverprofile=coverage.txt -covermode=atomic \
-            -run '^(TestProtocol6ProviderServerConfigure)' \
-            ./...
+            -run '^(TestAcc|TestProtocol6ProviderServerConfigure)' \
+            ./... 2>&1 | tee test-output
+          go install github.com/jstemmer/go-junit-report/v2@latest
+          $(go env GOPATH)/bin/go-junit-report -in test-output -set-exit-code -iocopy	-out junit.xml
         env:
           TF_ACC: "1"
-          TF_LOG: DEBUG
+          TF_LOG: WARN
           COOLIFY_ENDPOINT: ${{ secrets.ACC_COOLIFY_ENDPOINT }}
           COOLIFY_TOKEN: ${{ secrets.ACC_COOLIFY_TOKEN }}
-        timeout-minutes: 10
+        timeout-minutes: 11
 
-      # - uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
-      #   if: ${{ !cancelled() && !startsWith(github.head_ref, 'renovate/') && matrix.tool == 'terraform' && matrix.version == 'v1.9.x' }}
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     flags: acceptance
-      # - uses: codecov/test-results-action@4e79e65778be1cecd5df25e14af1eafb6df80ea9 # v1.0.2
-      #   if: ${{ !cancelled() }}
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     flags: acceptance
+      - uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
+        if: ${{ !cancelled() && !startsWith(github.head_ref, 'renovate/') && matrix.tool == 'terraform' && matrix.version == 'v1.9.x' }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: acceptance
+      - uses: codecov/test-results-action@4e79e65778be1cecd5df25e14af1eafb6df80ea9 # v1.0.2
+        if: ${{ !cancelled() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: acceptance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,28 +143,27 @@ jobs:
           statedir: /tmp/tailscale-state/
           tags: tag:ci
           version: 1.76.6
-      - run: |
+      - name: Run Acceptance Tests
+        run: |
           go clean -testcache
-          go test -v \
+          go test -v -timeout=5m \
             -cover -coverprofile=coverage.txt -covermode=atomic \
-            -run '^(TestAcc|TestProtocol6ProviderServerConfigure)' \
-            ./... 2>&1 | tee test-output
-          go install github.com/jstemmer/go-junit-report/v2@latest
-          $(go env GOPATH)/bin/go-junit-report -in test-output -set-exit-code -iocopy	-out junit.xml
+            -run '^(TestProtocol6ProviderServerConfigure)' \
+            ./...
         env:
           TF_ACC: "1"
-          TF_LOG: WARN
+          TF_LOG: DEBUG
           COOLIFY_ENDPOINT: ${{ secrets.ACC_COOLIFY_ENDPOINT }}
           COOLIFY_TOKEN: ${{ secrets.ACC_COOLIFY_TOKEN }}
-        timeout-minutes: 10
+        timeout-minutes: 6
 
-      - uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
-        if: ${{ !cancelled() && !startsWith(github.head_ref, 'renovate/') && matrix.tool == 'terraform' && matrix.version == 'v1.9.x' }}
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: acceptance
-      - uses: codecov/test-results-action@4e79e65778be1cecd5df25e14af1eafb6df80ea9 # v1.0.2
-        if: ${{ !cancelled() }}
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: acceptance
+      # - uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
+      #   if: ${{ !cancelled() && !startsWith(github.head_ref, 'renovate/') && matrix.tool == 'terraform' && matrix.version == 'v1.9.x' }}
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     flags: acceptance
+      # - uses: codecov/test-results-action@4e79e65778be1cecd5df25e14af1eafb6df80ea9 # v1.0.2
+      #   if: ${{ !cancelled() }}
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     flags: acceptance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,9 +144,7 @@ jobs:
           tags: tag:ci
           version: 1.78.1
       - name: Check Coolify API health
-        run: |
-          response=$(curl -sf "${COOLIFY_ENDPOINT}/../health" || echo "Failed to connect")
-          echo "$response" | grep -q "^OK$" || { echo "Health check failed. Got: $response"; exit 1; }
+        run: curl --silent --fail --max-time 15 "${COOLIFY_ENDPOINT}/../health" | grep --quiet "^OK$"
         env:
           COOLIFY_ENDPOINT: ${{ secrets.ACC_COOLIFY_ENDPOINT }}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -173,7 +173,7 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 			require.NoError(t, err)
 
 			if test.expectedSuccess {
-				assert.Empty(t, resp.Diagnostics)
+				assert.Empty(t, resp.Diagnostics, "Expected no configuration errors but got: %+v", resp.Diagnostics)
 			} else {
 				assert.NotEmpty(t, resp.Diagnostics)
 			}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -158,8 +158,6 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 				t.Setenv(key, value)
 			}
 
-			t.Logf("config: %+v", test.config)
-
 			providerServer, err := acctest.TestAccProtoV6ProviderFactories["coolify"]()
 			require.NotNil(t, providerServer)
 			require.NoError(t, err)
@@ -175,15 +173,7 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 			require.NoError(t, err)
 
 			if test.expectedSuccess {
-				assert.Empty(t, resp.Diagnostics, "Expected no configuration errors but got: %+v", resp.Diagnostics)
-				if len(resp.Diagnostics) > 0 {
-					// log each error
-					for _, diag := range resp.Diagnostics {
-						t.Logf("error: %s", diag.Summary)
-						t.Logf("error det: %s", diag.Detail)
-
-					}
-				}
+				assert.Empty(t, resp.Diagnostics)
 			} else {
 				assert.NotEmpty(t, resp.Diagnostics)
 			}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -158,6 +158,8 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 				t.Setenv(key, value)
 			}
 
+			t.Logf("config: %+v", test.config)
+
 			providerServer, err := acctest.TestAccProtoV6ProviderFactories["coolify"]()
 			require.NotNil(t, providerServer)
 			require.NoError(t, err)
@@ -174,6 +176,14 @@ func TestProtocol6ProviderServerConfigure(t *testing.T) {
 
 			if test.expectedSuccess {
 				assert.Empty(t, resp.Diagnostics, "Expected no configuration errors but got: %+v", resp.Diagnostics)
+				if len(resp.Diagnostics) > 0 {
+					// log each error
+					for _, diag := range resp.Diagnostics {
+						t.Logf("error: %s", diag.Summary)
+						t.Logf("error det: %s", diag.Detail)
+
+					}
+				}
 			} else {
 				assert.NotEmpty(t, resp.Diagnostics)
 			}


### PR DESCRIPTION
WIP - Acceptance tests are failing, but only in CI/CD... Failures started suddenly with no changes to relevant files. No helpful debug logs.
Could be related to the http retry client, or Tailscale tunnel to test instance.